### PR TITLE
CI/CD: add more wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,20 +66,8 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux' && runner.arch == 'X64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-          # This should be temporary
-          # xref https://github.com/docker/setup-qemu-action/issues/188
-          # xref https://github.com/tonistiigi/binfmt/issues/215
-          image: tonistiigi/binfmt:qemu-v8.1.5
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_LINUX: ${{ runner.arch == 'X64' && 'auto ppc64le s390x' || 'auto armv7l' }}
         with:
           output-dir: dist-wheel-${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,16 @@ jobs:
         with:
           fetch-depth: "0"
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS_LINUX: ${{ runner.arch == 'X64' && 'auto ppc64le s390x' || 'auto armv7l' }}
         with:
           output-dir: dist-wheel-${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,6 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
         ver:
-          - { py: "3.8", np: "==1.20.0" }
           - { py: "3.9", np: "==1.20.0" }
           - { py: "3.10", np: "==1.21.6" }
           - { py: "3.11", np: "==1.23.2" }
@@ -93,8 +92,6 @@ jobs:
           - { py: "3.13", np: "==2.1.0" }
           - { py: "3.13", np: ">=2.1.0" }
         exclude:
-          - os: macos-14
-            ver: { py: "3.8", np: "==1.20.0" }
           - os: macos-14
             ver: { py: "3.9", np: "==1.20.0" }
           - os: macos-14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,10 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+          # This should be temporary
+          # xref https://github.com/docker/setup-qemu-action/issues/188
+          # xref https://github.com/tonistiigi/binfmt/issues/215
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        # macos-13 is an intel runner, macos-latest is apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ target-version = [
 # Switch to using build
 build-frontend = "build"
 # Disable building py3.6/7/8, pp3.8, 32bit
-skip = ["cp36-*", "cp37-*", "cp38-*", "pp38-*", "*-win32", "*-manylinux_i686"]
+skip = ["cp36-*", "cp37-*", "cp38-*", "pp38-*", "*-win32", "*_i686"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,14 @@ requires = [
     "setuptools>=64",
     "setuptools<72.2; implementation_name == 'pypy'", # https://github.com/pypa/distutils/issues/283
     "setuptools_scm>=7",
-    "numpy>=2.0.0rc1; python_version >= '3.9'",
-    "oldest-supported-numpy; python_version < '3.9'",
+    "numpy>=2.0.0rc1",
     "Cython>=3.0.10,<3.1.0",
     "extension-helpers>=1",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 name = "gstools_cython"
 description = "Cython backend for GSTools."
 authors = [
@@ -34,7 +33,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -92,11 +90,11 @@ multi_line_output = 3
 
 [tool.black]
 target-version = [
-    "py38",
     "py39",
     "py310",
     "py311",
     "py312",
+    "py313",
 ]
 
 [tool.coverage]
@@ -145,8 +143,8 @@ target-version = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-# Disable building py3.6/7
-skip = ["cp36-*", "cp37-*", "pp38-macosx_arm64", "*-win32", "*-manylinux_i686"]
+# Disable building py3.6/7/8, pp3.8, 32bit
+skip = ["cp36-*", "cp37-*", "cp38-*", "pp38-*", "*-win32", "*-manylinux_i686"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=64",
-    "setuptools<72.2; python_version < '3.9' and implementation_name == 'pypy'", # https://github.com/pypa/distutils/issues/283
+    "setuptools<72.2; implementation_name == 'pypy'", # https://github.com/pypa/distutils/issues/283
     "setuptools_scm>=7",
     "numpy>=2.0.0rc1; python_version >= '3.9'",
     "oldest-supported-numpy; python_version < '3.9'",
@@ -146,7 +146,7 @@ target-version = [
 # Switch to using build
 build-frontend = "build"
 # Disable building py3.6/7
-skip = ["cp36-*", "cp37-*"]
+skip = ["cp36-*", "cp37-*", "pp38-macosx_arm64"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ target-version = [
 # Switch to using build
 build-frontend = "build"
 # Disable building py3.6/7
-skip = ["cp36-*", "cp37-*", "pp38-macosx_arm64"]
+skip = ["cp36-*", "cp37-*", "pp38-macosx_arm64", "*-win32", "*-manylinux_i686"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=64",
+    "setuptools<72.2; python_version < '3.9' and implementation_name == 'pypy'", # https://github.com/pypa/distutils/issues/283
     "setuptools_scm>=7",
     "numpy>=2.0.0rc1; python_version >= '3.9'",
     "oldest-supported-numpy; python_version < '3.9'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,8 @@ target-version = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
-# Disable building PyPy wheels on all platforms, 32bit for py3.10/11/12, musllinux builds, py3.6/7
-skip = ["cp36-*", "cp37-*", "pp*", "*-win32", "*-manylinux_i686", "*-musllinux_*"]
+# Disable building py3.6/7
+skip = ["cp36-*", "cp37-*"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ target-version = [
 [tool.cibuildwheel]
 # Switch to using build
 build-frontend = "build"
+# explicitly enable pypy
+enable = ["pypy"]
 # Disable building py3.6/7/8, pp3.8, 32bit
 skip = ["cp36-*", "cp37-*", "cp38-*", "pp38-*", "*-win32", "*_i686"]
 # Run the package tests using `pytest`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,8 +145,8 @@ target-version = [
 build-frontend = "build"
 # explicitly enable pypy
 enable = ["pypy"]
-# Disable building py3.6/7/8, pp3.8, 32bit
-skip = ["cp36-*", "cp37-*", "cp38-*", "pp38-*", "*-win32", "*_i686"]
+# Disable building py3.6/7/8, pp3.8, 32bit linux
+skip = ["cp36-*", "cp37-*", "cp38-*", "pp38-*", "*_i686"]
 # Run the package tests using `pytest`
 test-extras = "test"
 test-command = "pytest -v {package}/tests"


### PR DESCRIPTION
- dropping Python 3.8 ([EOL reached](https://devguide.python.org/versions/))
- adding [musllinux](https://musl.libc.org/) wheels
- adding PyPy wheels (pp39 and pp310)
  - PyPy needs `setuptools<72.2`: https://github.com/pypa/distutils/issues/283
- adding 32bit Windows wheels again (still Tier 1 support in Python)
- adding aarch64 Linux wheels